### PR TITLE
fix a variety of bugs in Copy()

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -329,15 +329,21 @@ func (n *Node) Copy() *Node {
 	}
 
 	for i, p := range n.Pointers {
-		pp := nn.Pointers[i]
-		pp.Link = p.Link
+		pp := &Pointer{}
+		if p.Link != nil {
+			newCid := *p.Link
+			pp.Link = &newCid
+		}
 		pp.KVs = make([]*KV, len(p.KVs))
 		for j, kv := range p.KVs {
-			pp.KVs[j] = &KV{Key: kv.Key, Value: kv.Value}
+			val := make([]byte, len(kv.Value))
+			copy(val, kv.Value)
+			pp.KVs[j] = &KV{Key: kv.Key, Value: val}
 		}
+		nn.Pointers[i] = pp
 	}
 
-	return n
+	return nn
 }
 
 func (p *Pointer) isShard() bool {

--- a/hamt.go
+++ b/hamt.go
@@ -324,7 +324,7 @@ func (n *Node) getChild(i byte) *Pointer {
 
 func (n *Node) Copy() *Node {
      nn := NewNode(n.store)
-     nn.Bitfield = big.NewInt(0).Set(n.Bitfield)
+     nn.Bitfield.Set(n.Bitfield)
      nn.Pointers = make([]*Pointer, len(n.Pointers))
 
 	for i, p := range n.Pointers {

--- a/hamt.go
+++ b/hamt.go
@@ -6,7 +6,7 @@ import (
 	"hash/fnv"
 	"math/big"
 
-	cid "github.com/ipfs/go-cid"
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
 
 const arrayWidth = 3

--- a/hamt.go
+++ b/hamt.go
@@ -323,11 +323,9 @@ func (n *Node) getChild(i byte) *Pointer {
 }
 
 func (n *Node) Copy() *Node {
-	nn := &Node{
-		store:    n.store,
-		Bitfield: big.NewInt(0).Set(n.Bitfield),
-		Pointers: make([]*Pointer, len(n.Pointers)),
-	}
+     nn := NewNode(n.store)
+     nn.Bitfield = big.NewInt(0).Set(n.Bitfield)
+     nn.Pointers = make([]*Pointer, len(n.Pointers))
 
 	for i, p := range n.Pointers {
 		pp := &Pointer{}

--- a/hamt.go
+++ b/hamt.go
@@ -23,6 +23,7 @@ func NewNode(cs *CborIpldStore) *Node {
 	return &Node{
 		Bitfield: big.NewInt(0),
 		store:    cs,
+		Pointers: make([]*Pointer, 0),
 	}
 }
 

--- a/hamt.go
+++ b/hamt.go
@@ -323,9 +323,9 @@ func (n *Node) getChild(i byte) *Pointer {
 }
 
 func (n *Node) Copy() *Node {
-     nn := NewNode(n.store)
-     nn.Bitfield.Set(n.Bitfield)
-     nn.Pointers = make([]*Pointer, len(n.Pointers))
+	nn := NewNode(n.store)
+	nn.Bitfield.Set(n.Bitfield)
+	nn.Pointers = make([]*Pointer, len(n.Pointers))
 
 	for i, p := range n.Pointers {
 		pp := &Pointer{}

--- a/hamt.go
+++ b/hamt.go
@@ -6,7 +6,7 @@ import (
 	"hash/fnv"
 	"math/big"
 
-	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	cid "github.com/ipfs/go-cid"
 )
 
 const arrayWidth = 3

--- a/hamt.go
+++ b/hamt.go
@@ -329,10 +329,7 @@ func (n *Node) Copy() *Node {
 
 	for i, p := range n.Pointers {
 		pp := &Pointer{}
-		if p.Link != nil {
-			newCid := *p.Link
-			pp.Link = &newCid
-		}
+		pp.Link = p.Link
 		pp.KVs = make([]*KV, len(p.KVs))
 		for j, kv := range p.KVs {
 			val := make([]byte, len(kv.Value))

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -175,3 +175,48 @@ func TestSetGet(t *testing.T) {
 		}
 	}
 }
+
+func nodesEqual(t *testing.T, store *CborIpldStore, n1, n2 *Node) bool {
+	ctx := context.Background()
+	err := n1.Flush(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n1Cid, err := store.Put(ctx, n1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n2.Flush(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2Cid, err := store.Put(ctx, n2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n1Cid.Equals(n2Cid)
+}
+
+func TestCopy(t *testing.T) {
+	ctx := context.Background()
+	cs := NewCborStore()
+
+	n := NewNode(cs)
+	nc := n.Copy()
+	if !nodesEqual(t, cs, n, nc) {
+		t.Fatal("nodes should be equal")
+	}
+	n.Set(ctx, "key", []byte{0x01})	
+	if nodesEqual(t, cs, n, nc) {
+		t.Fatal("nodes should not be equal -- we set a key on n")
+	}
+	nc = n.Copy()
+	nc.Set(ctx, "key2", []byte{0x02})
+	if nodesEqual(t, cs, n, nc) {
+		t.Fatal("nodes should not be equal -- we set a key on nc")
+	}
+	n = nc.Copy()
+	if !nodesEqual(t, cs, n, nc) {
+		t.Fatal("nodes should be equal")
+	}
+}

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -206,7 +206,7 @@ func TestCopy(t *testing.T) {
 	if !nodesEqual(t, cs, n, nc) {
 		t.Fatal("nodes should be equal")
 	}
-	n.Set(ctx, "key", []byte{0x01})	
+	n.Set(ctx, "key", []byte{0x01})
 	if nodesEqual(t, cs, n, nc) {
 		t.Fatal("nodes should not be equal -- we set a key on n")
 	}

--- a/ipld.go
+++ b/ipld.go
@@ -11,11 +11,11 @@ import (
 		offline "github.com/ipfs/go-ipfs/exchange/offline"
 	*/
 
-	cbor "gx/ipfs/QmRVSCwQtW1rjHCay9NqKXDwbtKTgDcN4iY7PrpSqfKM5D/go-ipld-cbor"
-	atlas "gx/ipfs/QmcrriCMhjb5ZWzmPNxmP53px47tSPcXBNaMtLdgcKFJYk/refmt/obj/atlas"
-	block "gx/ipfs/Qmej7nf81hi2x2tvjRBF3mcp74sQyuDH4VMYDGd1YtXjb2/go-block-format"
+	block "github.com/ipfs/go-block-format"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	atlas "github.com/polydawn/refmt/obj/atlas"
 	//ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
-	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
+	cid "github.com/ipfs/go-cid"
 )
 
 // THIS IS ALL TEMPORARY CODE

--- a/ipld.go
+++ b/ipld.go
@@ -11,11 +11,11 @@ import (
 		offline "github.com/ipfs/go-ipfs/exchange/offline"
 	*/
 
-	block "github.com/ipfs/go-block-format"
-	cbor "github.com/ipfs/go-ipld-cbor"
-	atlas "github.com/polydawn/refmt/obj/atlas"
+	cbor "gx/ipfs/QmRVSCwQtW1rjHCay9NqKXDwbtKTgDcN4iY7PrpSqfKM5D/go-ipld-cbor"
+	atlas "gx/ipfs/QmcrriCMhjb5ZWzmPNxmP53px47tSPcXBNaMtLdgcKFJYk/refmt/obj/atlas"
+	block "gx/ipfs/Qmej7nf81hi2x2tvjRBF3mcp74sQyuDH4VMYDGd1YtXjb2/go-block-format"
 	//ds "gx/ipfs/QmdHG8MAuARdGHxx4rPQASLcvhz24fzjSQq7AJRAQEorq5/go-datastore"
-	cid "github.com/ipfs/go-cid"
+	cid "gx/ipfs/QmcZfnkapfECQGcLZaf9B79NRg7cRa9EnZh4LSbkCzwNvY/go-cid"
 )
 
 // THIS IS ALL TEMPORARY CODE


### PR DESCRIPTION
- wrong return value
- use of nn.Pointers[i] before initialization
- use constructor to create new node for good measure (if we initialize Pointers as nil in one case but with make in another we get different cid)
- aliasing issues with kv.Value and p.Link. These didn't cause actual problems that I saw, but seems like they easily could.
