### PR TITLE
use new version of go-ipld-cbor

### DIFF
--- a/ipld.go
+++ b/ipld.go
@@ -21,6 +21,7 @@ import (
 // THIS IS ALL TEMPORARY CODE
 
 func init() {
+        cbor.RegisterCborType(cbor.BigIntAtlasEntry)
 	cbor.RegisterCborType(Node{})
 	cbor.RegisterCborType(Pointer{})
 

--- a/ipld.go
+++ b/ipld.go
@@ -21,7 +21,7 @@ import (
 // THIS IS ALL TEMPORARY CODE
 
 func init() {
-        cbor.RegisterCborType(cbor.BigIntAtlasEntry)
+	cbor.RegisterCborType(cbor.BigIntAtlasEntry)
 	cbor.RegisterCborType(Node{})
 	cbor.RegisterCborType(Pointer{})
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmRVSCwQtW1rjHCay9NqKXDwbtKTgDcN4iY7PrpSqfKM5D",
+      "hash": "QmRiRJhn427YVuufBEHofLreKWNw7P7BWNq86Sb9kzqdbd",
       "name": "go-ipld-cbor",
-      "version": "1.3.1"
+      "version": "1.4.1"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
go-filecoin is using 1.4.1 and the hamt version has to be in sync with the application version in order to use the same atlas