### PR TITLE
Bump version & publish

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.7: QmdtiofXbibTe6Day9ii5zjBZpSRm8vhfoerrNuY3sAQ7e
+0.0.8: QmcYBp5EDnJKfVN63F71rDTksvEf1cfijwCTWtw6bPG58T

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "",
   "name": "go-hamt-ipld",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.7"
+  "version": "0.0.8"
 }
 


### PR DESCRIPTION
So we can use in go-filecoin. This PR depends on https://github.com/ipfs/go-hamt-ipld/pull/10.