### PR TITLE
add codegen for serialization of hamt types

### DIFF
--- a/cbor_gen.go
+++ b/cbor_gen.go
@@ -1,0 +1,181 @@
+package hamt
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+	xerrors "golang.org/x/xerrors"
+)
+
+// NOTE: This is a generated file, but it has been modified to encode the
+// bitfield big.Int as a byte array. The bitfield is only a big.Int because
+// thats a convenient type for the operations we need to perform on it, but it
+// is fundamentally an array of bytes (bits)
+
+var _ = xerrors.Errorf
+
+func (t *Node) MarshalCBOR(w io.Writer) error {
+	if _, err := w.Write([]byte{130}); err != nil {
+		return err
+	}
+
+	// t.t.Bitfield (big.Int)
+	{
+		var b []byte
+		if t.Bitfield != nil {
+			b = t.Bitfield.Bytes()
+		}
+
+		if err := cbg.CborWriteHeader(w, cbg.MajByteString, uint64(len(b))); err != nil {
+			return err
+		}
+		if _, err := w.Write(b); err != nil {
+			return err
+		}
+	}
+
+	// t.t.Pointers ([]*hamt.Pointer)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajArray, uint64(len(t.Pointers)))); err != nil {
+		return err
+	}
+	for _, v := range t.Pointers {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Node) UnmarshalCBOR(br io.Reader) error {
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.t.Bitfield (big.Int)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("big ints should be tagged cbor byte strings")
+	}
+
+	if extra > 256 {
+		return fmt.Errorf("cbor bignum was too large")
+	}
+
+	if extra > 0 {
+		buf := make([]byte, extra)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			return err
+		}
+		t.Bitfield = big.NewInt(0).SetBytes(buf)
+	}
+	// t.t.Pointers ([]*hamt.Pointer)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if extra > 8192 {
+		return fmt.Errorf("array too large")
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+	if extra > 0 {
+		t.Pointers = make([]*Pointer, extra)
+	}
+	for i := 0; i < int(extra); i++ {
+		var v Pointer
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Pointers[i] = &v
+	}
+
+	return nil
+}
+
+func (t *KV) MarshalCBOR(w io.Writer) error {
+	if _, err := w.Write([]byte{130}); err != nil {
+		return err
+	}
+
+	// t.t.Key (string)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajTextString, uint64(len(t.Key)))); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte(t.Key)); err != nil {
+		return err
+	}
+
+	// t.t.Value (typegen.Deferred)
+
+	if err := t.Value.MarshalCBOR(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *KV) UnmarshalCBOR(br io.Reader) error {
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.t.Key (string)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajTextString {
+		return fmt.Errorf("expected cbor type 'text string' in input")
+	}
+
+	if extra > 256*1024 {
+		return fmt.Errorf("string in cbor input too long")
+	}
+
+	{
+		buf := make([]byte, extra)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			return err
+		}
+
+		t.Key = string(buf)
+	}
+	// t.t.Value (typegen.Deferred)
+
+	t.Value = new(cbg.Deferred)
+
+	if err := t.Value.UnmarshalCBOR(br); err != nil {
+		return err
+	}
+	return nil
+}

--- a/gen/main.go
+++ b/gen/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+
+	hamt "github.com/ipfs/go-hamt-ipld"
+)
+
+func main() {
+	fi, err := os.Create("cbor_gen.go")
+	if err != nil {
+		panic(err)
+	}
+	defer fi.Close()
+
+	if err := cbg.PrintHeaderAndUtilityMethods(fi, "hamt"); err != nil {
+		panic(err)
+	}
+
+	t := []interface{}{
+		hamt.Node{},
+		hamt.KV{},
+		hamt.Pointer{},
+	}
+
+	for _, t := range t {
+		if err := cbg.GenTupleEncodersForType(t, fi); err != nil {
+			panic(err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-ipld-cbor v0.0.3
+	github.com/multiformats/go-multihash v0.0.1
 	github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72
-	github.com/whyrusleeping/cbor-gen v0.0.0-20190822002707-4e02357de5c1
+	github.com/whyrusleeping/cbor-gen v0.0.0-20190822231004-8db835b09a5a
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gxed/hashland/keccakpg v0.0.1 h1:wrk3uMNaMxbXiHibbPO4S0ymqJMm41WiudyFSs7UnsU=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
@@ -6,7 +5,6 @@ github.com/gxed/hashland/murmur3 v0.0.1 h1:SheiaIt0sda5K+8FLz952/1iWS9zrnKsEJaOJ
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
-github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3 h1:UIAh32wymBpStoe83YCzwVQQ5Oy/H0FdxvUS6DJDzms=
@@ -17,7 +15,6 @@ github.com/ipfs/go-ipld-cbor v0.0.3 h1:ENsxvybwkmke7Z/QJOmeJfoguj6GH3Y0YOaGrfy9Q
 github.com/ipfs/go-ipld-cbor v0.0.3/go.mod h1:wTBtrQZA3SoFKMVkp6cn6HMRteIB1VsmHA0AQFOn7Nc=
 github.com/ipfs/go-ipld-format v0.0.1 h1:HCu4eB/Gh+KD/Q0M8u888RFkorTWNIL3da4oc5dwc80=
 github.com/ipfs/go-ipld-format v0.0.1/go.mod h1:kyJtbkDALmFHv3QR6et67i35QzO3S0dCDnkOJhcZkms=
-github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
@@ -33,20 +30,18 @@ github.com/multiformats/go-multihash v0.0.1 h1:HHwN1K12I+XllBCrqKnhX949Orn4oawPk
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992 h1:bzMe+2coZJYHnhGgVlcQKuRy4FSny4ds8dLQjw5P1XE=
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa h1:E+gaaifzi2xF65PbDmuKI3PhLWY6G5opMLniFq8vmXA=
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa/go.mod h1:2RVY1rIf+2J2o/IM9+vPq9RzmHDSseB7FoXiSNIUsoU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
-github.com/whyrusleeping/cbor-gen v0.0.0-20190821171244-dffbd9058edd h1:/+iPDLukqBcSkxCg5gANy2sv0weWQmLAsdeV669XttU=
-github.com/whyrusleeping/cbor-gen v0.0.0-20190821171244-dffbd9058edd/go.mod h1:38LwjsrZy8ga8AbyOueCsLUAtdc1BDj/I929R+LnJfI=
 github.com/whyrusleeping/cbor-gen v0.0.0-20190822002707-4e02357de5c1 h1:wDIXmhgPVpV1gWj68IIj1zQNyp7QzBvr5d5UOvMqRNw=
 github.com/whyrusleeping/cbor-gen v0.0.0-20190822002707-4e02357de5c1/go.mod h1:xdlJQaiqipF0HW+Mzpg7XRM3fWbGvfgFlcppuvlkIvY=
+github.com/whyrusleeping/cbor-gen v0.0.0-20190822231004-8db835b09a5a h1:9oEQR9eq2H2JDmglMcrCa+TxUEYy3HKSiNoLIkPNy/U=
+github.com/whyrusleeping/cbor-gen v0.0.0-20190822231004-8db835b09a5a/go.mod h1:xdlJQaiqipF0HW+Mzpg7XRM3fWbGvfgFlcppuvlkIvY=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 h1:ng3VDlRp5/DHpSWl02R4rM9I+8M2rhmsuLwAMmkLQWE=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d h1:Z0Ahzd7HltpJtjAHHxX8QFP3j1yYgiuvjbjRzDj/KH0=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hamt_bench_test.go
+++ b/hamt_bench_test.go
@@ -87,8 +87,7 @@ func doBenchmarkEntriesCount(num int) func(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			_, err = nd.Find(context.TODO(), keys[i%num])
-			if err != nil {
+			if err = nd.Find(context.TODO(), keys[i%num], nil); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/pointer_cbor.go
+++ b/pointer_cbor.go
@@ -1,0 +1,127 @@
+package hamt
+
+import (
+	"fmt"
+	"io"
+
+	cid "github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+func (t *Pointer) MarshalCBOR(w io.Writer) error {
+	if t.Link != cid.Undef && len(t.KVs) > 0 {
+		return fmt.Errorf("hamt Pointer cannot have both a link and KVs")
+	}
+
+	if err := cbg.CborWriteHeader(w, cbg.MajMap, 1); err != nil {
+		return err
+	}
+
+	if t.Link != cid.Undef {
+		// key for links is "0"
+		// Refmt (and the general IPLD data model currently) can't deal
+		// with non string keys. So we have this weird restriction right now
+		// hoping to be able to use integer keys soon
+		if err := cbg.CborWriteHeader(w, cbg.MajTextString, 1); err != nil {
+			return err
+		}
+
+		if _, err := w.Write([]byte("0")); err != nil {
+			return err
+		}
+
+		if err := cbg.WriteCid(w, t.Link); err != nil {
+			return err
+		}
+	} else {
+		// key for KVs is "1"
+		if err := cbg.CborWriteHeader(w, cbg.MajTextString, 1); err != nil {
+			return err
+		}
+
+		if _, err := w.Write([]byte("1")); err != nil {
+			return err
+		}
+
+		if err := cbg.CborWriteHeader(w, cbg.MajArray, uint64(len(t.KVs))); err != nil {
+			return err
+		}
+
+		for _, kv := range t.KVs {
+			if err := kv.MarshalCBOR(w); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *Pointer) UnmarshalCBOR(br io.Reader) error {
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of map")
+	}
+
+	if extra != 1 {
+		return fmt.Errorf("Pointers should be a single element map")
+	}
+
+	maj, val, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajTextString {
+		return fmt.Errorf("expected text string key")
+	}
+
+	if val != 1 {
+		return fmt.Errorf("map keys in pointers must be a single byte long")
+	}
+
+	var b [1]byte
+	if _, err := io.ReadFull(br, b[:]); err != nil {
+		return err
+	}
+
+	switch string(b[:]) {
+	case "0":
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return err
+		}
+		t.Link = c
+		return nil
+	case "1":
+		maj, length, err := cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+
+		if maj != cbg.MajArray {
+			return fmt.Errorf("expected an array of KVs in cbor input")
+		}
+
+		if length > 32 {
+			return fmt.Errorf("KV array in cbor input for pointer was too long")
+		}
+
+		t.KVs = make([]*KV, length)
+		for i := 0; i < int(length); i++ {
+			var kv KV
+			if err := kv.UnmarshalCBOR(br); err != nil {
+				return err
+			}
+
+			t.KVs[i] = &kv
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("invalid pointer map key in cbor input: %d", val)
+	}
+}


### PR DESCRIPTION
This is mostly good, theres a bit of funk that i'm trying to figure out how to address, but thats mostly changes in the codegen itself, and not here (notably, i don't always want big.Int to turn into a tagged cbor bignum)