### PR TITLE
use an interface for the actual hamt parts instead of an internal type

### DIFF
--- a/ipld.go
+++ b/ipld.go
@@ -25,26 +25,6 @@ import (
 
 // THIS IS ALL TEMPORARY CODE
 
-/*
-func init() {
-	cbor.RegisterCborType(cbor.BigIntAtlasEntry)
-	cbor.RegisterCborType(Node{})
-	cbor.RegisterCborType(Pointer{})
-
-	kvAtlasEntry := atlas.BuildEntry(KV{}).Transform().TransformMarshal(
-		atlas.MakeMarshalTransformFunc(func(kv KV) ([]interface{}, error) {
-			return []interface{}{kv.Key, kv.Value}, nil
-		})).TransformUnmarshal(
-		atlas.MakeUnmarshalTransformFunc(func(v []interface{}) (KV, error) {
-			return KV{
-				Key:   v[0].(string),
-				Value: v[1],
-			}, nil
-		})).Complete()
-	cbor.RegisterCborType(kvAtlasEntry)
-}
-*/
-
 type CborIpldStore struct {
 	Blocks blocks
 	Atlas  *atlas.Atlas
@@ -101,6 +81,10 @@ func (mb *mockBlocks) AddBlock(b block.Block) error {
 
 func NewCborStore() *CborIpldStore {
 	return &CborIpldStore{Blocks: newMockBlocks()}
+}
+
+func (s *CborIpldStore) GetBlock(ctx context.Context, c cid.Cid) (block.Block, error) {
+	return s.Blocks.GetBlock(ctx, c)
 }
 
 func (s *CborIpldStore) Get(ctx context.Context, c cid.Cid, out interface{}) error {


### PR DESCRIPTION
This simply switches the hamt to use an interface instead of a struct type. This is probably part 1 in a couple of PRs. Our usecase is to use a blockservice (as opposed to a blockstore) for the underlying blockstore and that's basically impossible with the code as is. With this checkin, at least it would become *possible* - next step is to make the ipld.go file easier to use either a blockservice or a blockstore.