### PR TITLE
add special errors for denoting serialization issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20190910031516-c1cbffdb01bb
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 )
+
+go 1.13

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -273,6 +273,45 @@ func TestBasic(t *testing.T) {
 	}
 }
 
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+	cs := NewCborStore()
+	begn := NewNode(cs)
+
+	val := []byte("cat dog bear")
+	if err := begn.Set(ctx, "foo", val); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		if err := begn.Set(ctx, randString(), randValue()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := begn.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	c, err := cs.Put(ctx, begn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := LoadNode(ctx, cs, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := n.Delete(ctx, "foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out []byte
+	if err := n.Find(ctx, "foo", &out); err == nil {
+		t.Fatal("shouldnt have found object")
+	}
+}
+
 func TestSetGet(t *testing.T) {
 	ctx := context.Background()
 	vals := make(map[string][]byte)


### PR DESCRIPTION
The idea here is that we can catch these and handle them specially, theyre both pretty bad and we should avoid ever having these show up in production, but its not impossible.