### PR TITLE
indexForBit optimization

### DIFF
--- a/uhamt.go
+++ b/uhamt.go
@@ -8,36 +8,20 @@ import (
 // indexForBitPos returns the index within the collapsed array corresponding to
 // the given bit in the bitset.  The collapsed array contains only one entry
 // per bit set in the bitfield, and this function is used to map the indices.
-func (n *Node) indexForBitPosOld(bp int) int {
-	// TODO: an optimization could reuse the same 'mask' here and change the size
-	//       as needed. This isnt yet done as the bitset package doesnt make it easy
-	//       to do.
-
-	// make a bitmask (all bits set) 'bp' bits long
-	mask := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bp)), nil), big.NewInt(1))
-	mask.And(mask, n.Bitfield)
-
-	return popCount(mask)
-}
-
-func popCount(i *big.Int) int {
-	var n int
-	for _, v := range i.Bits() {
-		n += bits.OnesCount64(uint64(v))
-	}
-	return n
-}
-
 func (n *Node) indexForBitPos(bp int) int {
+	return indexForBitPos(bp, n.Bitfield)
+}
+
+func indexForBitPos(bp int, bitfield *big.Int) int {
 	var x uint
 	var count, i int
-	w := n.Bitfield.Bits()
+	w := bitfield.Bits()
 	for x = uint(bp); x > bits.UintSize && i < len(w); x -= bits.UintSize {
-		count += bits.OnesCount64(uint64(w[i]))
+		count += bits.OnesCount(uint(w[i]))
 		i++
 	}
 	if i == len(w) {
 		return count
 	}
-	return count + bits.OnesCount64(uint64(w[i])&((1<<x)-1))
+	return count + bits.OnesCount(uint(w[i])&((1<<x)-1))
 }

--- a/uhamt.go
+++ b/uhamt.go
@@ -29,10 +29,10 @@ func popCount(i *big.Int) int {
 }
 
 func (n *Node) indexForBitPos(bp int) int {
-	var x uint64
+	var x uint
 	var count, i int
 	w := n.Bitfield.Bits()
-	for x = uint64(bp); x > 64 && i < len(w); x -= 64 {
+	for x = uint(bp); x > bits.UintSize && i < len(w); x -= bits.UintSize {
 		count += bits.OnesCount64(uint64(w[i]))
 		i++
 	}

--- a/uhamt.go
+++ b/uhamt.go
@@ -8,7 +8,7 @@ import (
 // indexForBitPos returns the index within the collapsed array corresponding to
 // the given bit in the bitset.  The collapsed array contains only one entry
 // per bit set in the bitfield, and this function is used to map the indices.
-func (n *Node) indexForBitPos(bp int) int {
+func (n *Node) indexForBitPosOld(bp int) int {
 	// TODO: an optimization could reuse the same 'mask' here and change the size
 	//       as needed. This isnt yet done as the bitset package doesnt make it easy
 	//       to do.
@@ -26,4 +26,18 @@ func popCount(i *big.Int) int {
 		n += bits.OnesCount64(uint64(v))
 	}
 	return n
+}
+
+func (n *Node) indexForBitPos(bp int) int {
+	var x uint64
+	var count, i int
+	w := n.Bitfield.Bits()
+	for x = uint64(bp); x > 64 && i < len(w); x -= 64 {
+		count += bits.OnesCount64(uint64(w[i]))
+		i++
+	}
+	if i == len(w) {
+		return count
+	}
+	return count + bits.OnesCount64(uint64(w[i])&((1<<x)-1))
 }

--- a/uhamt_test.go
+++ b/uhamt_test.go
@@ -1,0 +1,57 @@
+package hamt
+
+import (
+	"math/big"
+	"math/bits"
+	"math/rand"
+	"testing"
+)
+
+func TestIndexForBitRandom(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(int64(42)))
+
+	count := 100000
+	slot := make([]byte, 32)
+	for i := 0; i < count; i++ {
+		_, err := r.Read(slot)
+		if err != nil {
+			t.Fatal("couldn't create random bitfield")
+		}
+		bi := big.NewInt(0).SetBytes(slot)
+		for k := 0; k < 256; k++ {
+			if indexForBitPos(k, bi) != indexForBitPosOriginal(k, bi) {
+				t.Fatalf("indexForBit doesn't match with original")
+			}
+		}
+	}
+}
+
+func TestIndexForBitLinear(t *testing.T) {
+	t.Parallel()
+	var i int64
+	for i = 0; i < 1<<16-1; i++ {
+		bi := big.NewInt(i)
+		for k := 0; k < 16; k++ {
+			if indexForBitPos(k, bi) != indexForBitPosOriginal(k, bi) {
+				t.Fatalf("indexForBit doesn't match with original")
+			}
+		}
+	}
+}
+
+// Original implementation of indexForBit, before #39.
+func indexForBitPosOriginal(bp int, bitfield *big.Int) int {
+	mask := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bp)), nil), big.NewInt(1))
+	mask.And(mask, bitfield)
+
+	return popCount(mask)
+}
+
+func popCount(i *big.Int) int {
+	var n int
+	for _, v := range i.Bits() {
+		n += bits.OnesCount64(uint64(v))
+	}
+	return n
+}


### PR DESCRIPTION
While getting to know the lib and playing around (beautiful data structure!), I ended up looking at some pprof were I noticed most of the allocs (count and size) for `Set` were in the bit calc regarding active slots for the bitwidth. Seems that was on the radar considering the existing comment.

I cleaned up the benchmark I was using to measure this (`BenchmarkSet`).
Then I tried to come up with another implementation which should have much less allocations.
Turns out it seems to make a big impact, here the `benchcmp`:
```
➜  go-hamt-ipld git:(setopt) ✗ benchcmp before.out after.out
benchmark                   old ns/op     new ns/op     delta
BenchmarkSet/1000/5-8       5434970       3767439       -30.68%
BenchmarkSet/1000/8-8       5334143       3846618       -27.89%
BenchmarkSet/10000/5-8      56021885      32351022      -42.25%
BenchmarkSet/10000/8-8      54762385      34444790      -37.10%
BenchmarkSet/100000/5-8     547704636     351883823     -35.75%
BenchmarkSet/100000/8-8     534793736     397958576     -25.59%

benchmark                   old allocs     new allocs     delta
BenchmarkSet/1000/5-8       57010          26353          -53.77%
BenchmarkSet/1000/8-8       50934          29709          -41.67%
BenchmarkSet/10000/5-8      560825         240196         -57.17%
BenchmarkSet/10000/8-8      511194         261228         -48.90%
BenchmarkSet/100000/5-8     5790539        2781380        -51.97%
BenchmarkSet/100000/8-8     5020547        3079226        -38.67%

benchmark                   old bytes     new bytes     delta
BenchmarkSet/1000/5-8       1803141       1151062       -36.16%
BenchmarkSet/1000/8-8       1937767       1370267       -29.29%
BenchmarkSet/10000/5-8      17631641      10604518      -39.86%
BenchmarkSet/10000/8-8      19236994      12051757      -37.35%
BenchmarkSet/100000/5-8     184884804     120835981     -34.64%
BenchmarkSet/100000/8-8     192682957     143161872     -25.70%
```
So that seems to indicate:
- ns/op -33%~
- allocs -50%~
- bytes -33%~

I kept both old and new impl in this branch if anyone wants to double-check easily renaming funcs and playing.  If it turns out this gets approved, I'll delete/rebase the old one for the final merging.

To be more sure about correctness, I did an extra check (not seen in this PR) that calls both old and new funcs and panics if return different results; it didn't panic for a `go test ./...` run nor with my added benchmark. 