### PR TITLE
Feat/set raw cbor

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -86,6 +86,15 @@ func (n *Node) Find(ctx context.Context, k string, out interface{}) error {
 	})
 }
 
+func (n *Node) FindRaw(ctx context.Context, k string) ([]byte, error) {
+	var ret []byte
+	err := n.getValue(ctx, &hashBits{b: hash(k)}, k, func(kv *KV) error {
+		ret = kv.Value.Raw
+		return nil
+	})
+	return ret, err
+}
+
 func (n *Node) Delete(ctx context.Context, k string) error {
 	return n.modifyValue(ctx, &hashBits{b: hash(k)}, k, nil)
 }

--- a/hamt.go
+++ b/hamt.go
@@ -203,6 +203,12 @@ func (n *Node) Flush(ctx context.Context) error {
 	return nil
 }
 
+// SetRaw sets key k to cbor bytes raw
+func (n *Node) SetRaw(ctx context.Context, k string, raw []byte) error {
+	d := &cbg.Deferred{Raw: raw}
+	return n.modifyValue(ctx, &hashBits{b: hash(k)}, k, d)
+}
+
 func (n *Node) Set(ctx context.Context, k string, v interface{}) error {
 	var d *cbg.Deferred
 


### PR DESCRIPTION
It would be nice to extend the HAMT interface to allow direct set and find of cbor bytes, allowing this package to interoperate with packages that define their own cbor enc/decoding separate from cbg and refmt.

This PR gets most of the way there, allowing go filecoin to remove refmt atlases for custom types in favor of running encode decode on its side of the package boundary.