### PR TITLE
Load-time block format validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ test:
 	go test ./...
 .PHONY: test
 
+coverage:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out
+.PHONY: coverage
+
 benchmark:
 	go test -bench=./...
 .PHONY: benchmark

--- a/hamt_utils_test.go
+++ b/hamt_utils_test.go
@@ -1,0 +1,18 @@
+package hamt
+
+// test utilities
+// from https://github.com/polydawn/refmt/blob/3d65705ee9f12dc0dfcc0dc6cf9666e97b93f339/cbor/cborFixtures_test.go#L81-L93
+
+func bcat(bss ...[]byte) []byte {
+	l := 0
+	for _, bs := range bss {
+		l += len(bs)
+	}
+	rbs := make([]byte, 0, l)
+	for _, bs := range bss {
+		rbs = append(rbs, bs...)
+	}
+	return rbs
+}
+
+func b(b byte) []byte { return []byte{b} }

--- a/uhamt.go
+++ b/uhamt.go
@@ -29,3 +29,13 @@ func indexForBitPos(bp int, bitfield *big.Int) int {
 	}
 	return count + bits.OnesCount(uint(w[i])&((1<<x)-1))
 }
+
+// How many elements does the bitfield say we should have? Count the ones.
+func (n *Node) bitsSetCount() int {
+	w := n.Bitfield.Bits()
+	count := 0
+	for _, b := range w {
+		count += bits.OnesCount(uint(b))
+	}
+	return count
+}


### PR DESCRIPTION
Includes #57, the first two commits. The changes so far are only in `LoadNode` and in the tests.

Adds in some simple helper functions into the tests to help manually build CBOR blobs that'll load and trigger various cases. Only got as far as ensuring that the bitmap and the number of elements aren't out of alignment. That can get stricter with #54 if we put in precisely the size of bitmap that we need for the array of elements.

Other things I'm working on in here are listed at the bottom of hamt_test.go. The aim is that this thing should refuse to load from blocks that smell funny (i.e. aren't exactly the right form). There should only be one way of representing this data and there should be no avenues for variation. That's an ideal and not strictly possible in the extreme sense for various reasons but we can get close.