### PR TITLE
Extend documentation around Flush and cached nodes

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -102,7 +102,24 @@ type Pointer struct {
 	KVs  []*KV   `refmt:"v,omitempty"`
 	Link cid.Cid `refmt:"l,omitempty"`
 
-	// cached node to avoid too many serialization operations
+	// cache is a pointer to an in-memory Node, which may or may not be present,
+	// and corresponds to the Link field, which also may or may not be present.
+	//
+	// If present, the cached Node should be semantically substitutable with the Link field.
+	// It makes no sense for a cache Node to be present if KVs is set.
+	// Link might not be set, if cache is present and is describing data that has never yet been serialized and stored.
+	//
+	// `loadChild` will short circut to returning this node if the pointer isn't nil;
+	// `loadChild` will also set this pointer when loading a node it wasn't yet present.
+	// `Flush` on a `Node` will iterate through each `Pointer` and `Put` its cache node if it's set
+	// (and also recurse to `Flush` on that `Node`), and then nil it -- in other words,
+	// `Flush` both writes out the cached data and zeros the cache in the same stroke.
+	// `Flush` will also assign `Link` in the process of `Put`'ing the 'cache' data.
+	// `Copy` will copy any cached nodes (and any Link fields).
+	//
+	// `Link` becomes defined either when you `Flush` or
+	// when a new shard is created during the course of `modifyValue`.
+	//
 	// TODO(rvagg): we should check that this is actually used optimally. Flush()
 	// performs a save of all of the cached nodes, but both Copy() and loadChild()
 	// will set them. In the case of loadChild() we're not expecting a mutation so
@@ -391,10 +408,21 @@ func (n *Node) checkSize(ctx context.Context) (uint64, error) {
 	return totsize, nil
 }
 
-// Flush saves and purges any cached Nodes recursively from this Node through
-// its (cached) children. Cached nodes primarily exist through the use of
-// Copy() operations where the entire graph is instantiated in memory and each
-// child pointer exists in cached form.
+// Flush has two effects: it (partially!) persists data, and simultaneously drops it from memory.
+//
+// Flush operates recursively, telling each "cache" child node to flush;
+// Put'ing that "cache" node to the store;
+// updating this node's Link to the CID resulting from the store Put;
+// dropping the "cache" pointer to that node;
+// and then returning.
+// Flush doesn't operate unless there's a "cache" node.
+//
+// ("cache" nodes were previously storing either updated values,
+// or, simply storing previously loaded data; these are not disambiguated.)
+//
+// Notice that Flush _does not_ Put _this node_.
+// To fully persist changes, the caller still needs to Put this node to the store themselves,
+// and store the new resulting Link wherever they expect the updated HAMT to be seen.
 func (n *Node) Flush(ctx context.Context) error {
 	for _, p := range n.Pointers {
 		if p.cache != nil {
@@ -416,6 +444,12 @@ func (n *Node) Flush(ctx context.Context) error {
 
 // Set key k to value v, where v is has a MarshalCBOR(bytes.Buffer) method to
 // encode it.
+//
+// This may or may not cause immediate writes to the store,
+// depending on whether a new subshard is created.
+// Regardless, to fully commit the change, it is necessary to Flush the root Node,
+// and then additionally Put the root node to the store itself,
+// and save the resulting CID wherever you expect the HAMT root to persist.
 func (n *Node) Set(ctx context.Context, k string, v interface{}) error {
 	var d *cbg.Deferred
 
@@ -526,7 +560,10 @@ func (n *Node) modifyValue(ctx context.Context, hv *hashBits, k []byte, v *cbg.D
 	child := n.getPointer(cindex)
 	if child.isShard() {
 		// if isShard, we have a pointer to a child that we need to load and
-		// delegate our modify operation to
+		// delegate our modify operation to.
+		// Note that this loadChild operation will cause the loaded node to be "cached";
+		// it is an eventual Flush passing back over this "cache" node which causes the updates
+		// made to the in-memory "cache" node to eventually be persisted.
 		chnd, err := child.loadChild(ctx, n.store, n.bitWidth, n.hash)
 		if err != nil {
 			return err


### PR DESCRIPTION
It took me quite a while to understand what's going on here, so I extended the documentation around Flush, "cache" nodes, and in particular made some documentation about which functions actually carry which responsibilities for making persistence happen.  (It takes several of them, and the order matters -- this was not immediately obvious to me when I first inspected the code!)

I agree with the previous comments from @rvagg that something's probably not very optimal here, but I've also kept my scope to "document" rather than "change" for this diff.